### PR TITLE
BE/#19 `새 플레이리스트 생성하기` API 구현

### DIFF
--- a/src/main/java/com/example/dreamvalutbackend/domain/playlist/controller/PlaylistController.java
+++ b/src/main/java/com/example/dreamvalutbackend/domain/playlist/controller/PlaylistController.java
@@ -1,0 +1,39 @@
+package com.example.dreamvalutbackend.domain.playlist.controller;
+
+import java.net.URI;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+
+import com.example.dreamvalutbackend.domain.playlist.controller.request.CreatePlaylistRequestDto;
+import com.example.dreamvalutbackend.domain.playlist.controller.response.CreatePlaylistResponseDto;
+import com.example.dreamvalutbackend.domain.playlist.service.PlaylistService;
+
+import lombok.RequiredArgsConstructor;
+
+@Controller
+@RequiredArgsConstructor
+@RequestMapping("/playlists")
+public class PlaylistController {
+
+    private final PlaylistService playlistService;
+
+    @PostMapping
+    public ResponseEntity<CreatePlaylistResponseDto> createPlaylist(
+            @RequestBody CreatePlaylistRequestDto createPlaylistRequestDto) {
+        CreatePlaylistResponseDto createPlaylistResponseDto = playlistService.createPlaylist(createPlaylistRequestDto);
+
+        // HTTP 201 Created 상태 코드와 함께 생성된 리소스의 URI를 반환
+        URI location = ServletUriComponentsBuilder.fromCurrentRequest()
+                .path("/{playlist_id}")
+                .buildAndExpand(createPlaylistResponseDto.getPlaylistId())
+                .toUri();
+
+        return ResponseEntity.created(location)
+                .body(createPlaylistResponseDto);
+    }
+}

--- a/src/main/java/com/example/dreamvalutbackend/domain/playlist/controller/request/CreatePlaylistRequestDto.java
+++ b/src/main/java/com/example/dreamvalutbackend/domain/playlist/controller/request/CreatePlaylistRequestDto.java
@@ -1,0 +1,24 @@
+package com.example.dreamvalutbackend.domain.playlist.controller.request;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CreatePlaylistRequestDto {
+
+    @NotNull
+    private String playlistName;
+
+    @NotNull
+    private Boolean isPublic;
+
+    @Builder
+    public CreatePlaylistRequestDto(String playlistName, Boolean isPublic) {
+        this.playlistName = playlistName;
+        this.isPublic = isPublic;
+    }
+}

--- a/src/main/java/com/example/dreamvalutbackend/domain/playlist/controller/response/CreatePlaylistResponseDto.java
+++ b/src/main/java/com/example/dreamvalutbackend/domain/playlist/controller/response/CreatePlaylistResponseDto.java
@@ -8,13 +8,13 @@ import lombok.Getter;
 @Getter
 public class CreatePlaylistResponseDto {
 
-    private long playlistId;
+    private Long playlistId;
     private String playlistName;
     private Boolean isPublic;
     private Boolean isCurated;
 
     @Builder
-    public CreatePlaylistResponseDto(long playlistId, String playlistName, Boolean isPublic, Boolean isCurated) {
+    public CreatePlaylistResponseDto(Long playlistId, String playlistName, Boolean isPublic, Boolean isCurated) {
         this.playlistId = playlistId;
         this.playlistName = playlistName;
         this.isPublic = isPublic;

--- a/src/main/java/com/example/dreamvalutbackend/domain/playlist/controller/response/CreatePlaylistResponseDto.java
+++ b/src/main/java/com/example/dreamvalutbackend/domain/playlist/controller/response/CreatePlaylistResponseDto.java
@@ -1,0 +1,32 @@
+package com.example.dreamvalutbackend.domain.playlist.controller.response;
+
+import com.example.dreamvalutbackend.domain.playlist.domain.Playlist;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class CreatePlaylistResponseDto {
+
+    private long playlistId;
+    private String playlistName;
+    private Boolean isPublic;
+    private Boolean isCurated;
+
+    @Builder
+    public CreatePlaylistResponseDto(long playlistId, String playlistName, Boolean isPublic, Boolean isCurated) {
+        this.playlistId = playlistId;
+        this.playlistName = playlistName;
+        this.isPublic = isPublic;
+        this.isCurated = isCurated;
+    }
+
+    public static CreatePlaylistResponseDto toDto(Playlist playlist) {
+        return CreatePlaylistResponseDto.builder()
+                .playlistId(playlist.getId())
+                .playlistName(playlist.getPlaylistName())
+                .isPublic(playlist.getIsPublic())
+                .isCurated(playlist.getIsCurated())
+                .build();
+    }
+}

--- a/src/main/java/com/example/dreamvalutbackend/domain/playlist/domain/MyPlaylist.java
+++ b/src/main/java/com/example/dreamvalutbackend/domain/playlist/domain/MyPlaylist.java
@@ -26,4 +26,10 @@ public class MyPlaylist {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "playlist_id")
     private Playlist playlist;
+
+    @Builder
+    public MyPlaylist(User user, Playlist playlist) {
+        this.user = user;
+        this.playlist = playlist;
+    }
 }

--- a/src/main/java/com/example/dreamvalutbackend/domain/playlist/domain/Playlist.java
+++ b/src/main/java/com/example/dreamvalutbackend/domain/playlist/domain/Playlist.java
@@ -36,6 +36,15 @@ public class Playlist extends BaseTimeEntity {
     @JoinColumn(name = "user_id")
     private User user;
 
-    // @OneToMany(mappedBy = "playlist", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    // @OneToMany(mappedBy = "playlist", cascade = CascadeType.ALL, orphanRemoval =
+    // true, fetch = FetchType.LAZY)
     // private List<PlaylistTrack> playlistTracks = new ArrayList<>();
+
+    @Builder
+    public Playlist(String playlistName, Boolean isPublic, Boolean isCurated, User user) {
+        this.playlistName = playlistName;
+        this.isPublic = isPublic;
+        this.isCurated = isCurated;
+        this.user = user;
+    }
 }

--- a/src/main/java/com/example/dreamvalutbackend/domain/playlist/repository/MyPlaylistRepository.java
+++ b/src/main/java/com/example/dreamvalutbackend/domain/playlist/repository/MyPlaylistRepository.java
@@ -1,0 +1,9 @@
+package com.example.dreamvalutbackend.domain.playlist.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.example.dreamvalutbackend.domain.playlist.domain.MyPlaylist;
+
+public interface MyPlaylistRepository extends JpaRepository<MyPlaylist, Long> {
+
+}

--- a/src/main/java/com/example/dreamvalutbackend/domain/playlist/repository/PlaylistRepository.java
+++ b/src/main/java/com/example/dreamvalutbackend/domain/playlist/repository/PlaylistRepository.java
@@ -1,0 +1,9 @@
+package com.example.dreamvalutbackend.domain.playlist.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.example.dreamvalutbackend.domain.playlist.domain.Playlist;
+
+public interface PlaylistRepository extends JpaRepository<Playlist, Long> {
+
+}

--- a/src/main/java/com/example/dreamvalutbackend/domain/playlist/repository/PlaylistTrackRepository.java
+++ b/src/main/java/com/example/dreamvalutbackend/domain/playlist/repository/PlaylistTrackRepository.java
@@ -1,0 +1,9 @@
+package com.example.dreamvalutbackend.domain.playlist.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.example.dreamvalutbackend.domain.playlist.domain.PlaylistTrack;
+
+public interface PlaylistTrackRepository extends JpaRepository<PlaylistTrack, Long> {
+
+}

--- a/src/main/java/com/example/dreamvalutbackend/domain/playlist/service/PlaylistService.java
+++ b/src/main/java/com/example/dreamvalutbackend/domain/playlist/service/PlaylistService.java
@@ -1,0 +1,50 @@
+package com.example.dreamvalutbackend.domain.playlist.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.example.dreamvalutbackend.domain.playlist.controller.request.CreatePlaylistRequestDto;
+import com.example.dreamvalutbackend.domain.playlist.controller.response.CreatePlaylistResponseDto;
+import com.example.dreamvalutbackend.domain.playlist.domain.MyPlaylist;
+import com.example.dreamvalutbackend.domain.playlist.domain.Playlist;
+import com.example.dreamvalutbackend.domain.playlist.repository.MyPlaylistRepository;
+import com.example.dreamvalutbackend.domain.playlist.repository.PlaylistRepository;
+import com.example.dreamvalutbackend.domain.user.domain.User;
+import com.example.dreamvalutbackend.domain.user.repository.UserRepository;
+
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class PlaylistService {
+
+    private final PlaylistRepository playlistRepository;
+    private final MyPlaylistRepository myPlaylistRepository;
+    private final UserRepository userRepository;
+
+    @Transactional
+    public CreatePlaylistResponseDto createPlaylist(CreatePlaylistRequestDto createPlaylistRequestDto) {
+        // 유저 가져오기
+        User user = userRepository.findById(1L)
+                .orElseThrow(() -> new EntityNotFoundException("User not found with id: " + 1L));
+
+        // Playlist 생성
+        Playlist playlist = Playlist.builder()
+                .playlistName(createPlaylistRequestDto.getPlaylistName())
+                .isPublic(createPlaylistRequestDto.getIsPublic())
+                .isCurated(false)
+                .user(user)
+                .build();
+        Playlist savedPlaylist = playlistRepository.save(playlist);
+
+        // MyPlaylist 생성
+        MyPlaylist myPlaylist = MyPlaylist.builder()
+                .playlist(savedPlaylist)
+                .user(user)
+                .build();
+        myPlaylistRepository.save(myPlaylist);
+
+        return CreatePlaylistResponseDto.toDto(savedPlaylist);
+    }
+}

--- a/src/test/java/com/example/dreamvalutbackend/domain/playlist/controller/PlaylistControllerTest.java
+++ b/src/test/java/com/example/dreamvalutbackend/domain/playlist/controller/PlaylistControllerTest.java
@@ -1,0 +1,93 @@
+package com.example.dreamvalutbackend.domain.playlist.controller;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.example.dreamvalutbackend.domain.playlist.controller.request.CreatePlaylistRequestDto;
+import com.example.dreamvalutbackend.domain.playlist.repository.MyPlaylistRepository;
+import com.example.dreamvalutbackend.domain.playlist.repository.PlaylistRepository;
+import com.example.dreamvalutbackend.domain.user.domain.User;
+import com.example.dreamvalutbackend.domain.user.domain.UserRole;
+import com.example.dreamvalutbackend.domain.user.repository.UserRepository;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+public class PlaylistControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private UserRepository userRepository;
+    @Autowired
+    private PlaylistRepository playlistRepository;
+    @Autowired
+    private MyPlaylistRepository myPlaylistRepository;
+
+    private User user;
+
+    @BeforeEach
+    void setUp() {
+        user = User.builder()
+                .userName("testUserName")
+                .displayName("testDisplayName")
+                .userEmail("testEmail")
+                .profileImage("testProfileImage")
+                .role(UserRole.USER)
+                .socialId("testSocialId")
+                .build();
+        userRepository.save(user);
+    }
+
+    @AfterEach
+    void tearDown() {
+        myPlaylistRepository.deleteAll();
+        playlistRepository.deleteAll();
+        userRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("POST /playlists - Integration Success")
+    @Transactional
+    void createPlaylistSuccess() throws Exception {
+        /* Given */
+
+        CreatePlaylistRequestDto createPlaylistRequestDto = CreatePlaylistRequestDto.builder()
+                .playlistName("Test Playlist")
+                .isPublic(true)
+                .build();
+
+        String requestContent = objectMapper.writeValueAsString(createPlaylistRequestDto);
+
+        /* When & Then */
+        mockMvc.perform(post("/playlists")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestContent))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.playlistId").exists())
+                .andExpect(jsonPath("$.playlistName").value("Test Playlist"))
+                .andExpect(jsonPath("$.isPublic").value(true))
+                .andExpect(jsonPath("$.isCurated").value(false));
+    }
+}

--- a/src/test/java/com/example/dreamvalutbackend/domain/playlist/controller/PlaylistControllerUnitTest.java
+++ b/src/test/java/com/example/dreamvalutbackend/domain/playlist/controller/PlaylistControllerUnitTest.java
@@ -1,0 +1,74 @@
+package com.example.dreamvalutbackend.domain.playlist.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import com.example.dreamvalutbackend.domain.playlist.controller.request.CreatePlaylistRequestDto;
+import com.example.dreamvalutbackend.domain.playlist.controller.response.CreatePlaylistResponseDto;
+import com.example.dreamvalutbackend.domain.playlist.service.PlaylistService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public class PlaylistControllerUnitTest {
+
+    private MockMvc mockMvc;
+
+    @Mock
+    private PlaylistService playlistService;
+
+    @InjectMocks
+    private PlaylistController playlistController;
+
+    private ObjectMapper objectMapper = new ObjectMapper();
+
+    @BeforeEach
+    public void setUp() {
+        MockitoAnnotations.openMocks(this);
+        mockMvc = MockMvcBuilders.standaloneSetup(playlistController).build();
+    }
+
+    @Test
+    @DisplayName("POST /playlists - Unit Success")
+    public void createPlaylistSuccess() throws Exception {
+        /* Given */
+
+        // 요청할 CreatePlaylistRequestDto 객체 생성
+        CreatePlaylistRequestDto createPlaylistRequestDto = CreatePlaylistRequestDto.builder()
+                .playlistName("Test Playlist")
+                .isPublic(true)
+                .build();
+
+        // PlaylistService.createPlaylist() 메소드가 리턴할 CreatePlaylistResponseDto 객체 생성
+        CreatePlaylistResponseDto createPlaylistResponseDto = CreatePlaylistResponseDto.builder()
+                .playlistId(1L)
+                .playlistName("Test Playlist")
+                .isPublic(true)
+                .isCurated(false)
+                .build();
+
+        // PlaylistService.createPlaylist() 메소드 Mocking
+        given(playlistService.createPlaylist(any(CreatePlaylistRequestDto.class))).willReturn(createPlaylistResponseDto);
+
+        /* When & Then */
+        mockMvc.perform(post("/playlists")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(createPlaylistRequestDto)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.playlistId").value(1L))
+                .andExpect(jsonPath("$.playlistName").value("Test Playlist"))
+                .andExpect(jsonPath("$.isPublic").value(true))
+                .andExpect(jsonPath("$.isCurated").value(false));
+    }
+}

--- a/src/test/java/com/example/dreamvalutbackend/domain/playlist/service/PlaylistServiceTest.java
+++ b/src/test/java/com/example/dreamvalutbackend/domain/playlist/service/PlaylistServiceTest.java
@@ -1,0 +1,138 @@
+package com.example.dreamvalutbackend.domain.playlist.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import com.example.dreamvalutbackend.domain.playlist.controller.request.CreatePlaylistRequestDto;
+import com.example.dreamvalutbackend.domain.playlist.controller.response.CreatePlaylistResponseDto;
+import com.example.dreamvalutbackend.domain.playlist.domain.MyPlaylist;
+import com.example.dreamvalutbackend.domain.playlist.domain.Playlist;
+import com.example.dreamvalutbackend.domain.playlist.repository.MyPlaylistRepository;
+import com.example.dreamvalutbackend.domain.playlist.repository.PlaylistRepository;
+import com.example.dreamvalutbackend.domain.user.domain.User;
+import com.example.dreamvalutbackend.domain.user.domain.UserRole;
+import com.example.dreamvalutbackend.domain.user.repository.UserRepository;
+
+public class PlaylistServiceTest {
+
+    @Mock
+    private PlaylistRepository playlistRepository;
+    @Mock
+    private MyPlaylistRepository myPlaylistRepository;
+    @Mock
+    private UserRepository userRepository;
+
+    @InjectMocks
+    private PlaylistService playlistService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    @DisplayName("POST /playlist - Unit Success")
+    void createPlaylistSuccess() {
+        /* Given */
+
+        // 요청할 CreatePlaylistRequestDto 객체 생성
+        CreatePlaylistRequestDto createPlaylistRequestDto = CreatePlaylistRequestDto.builder()
+                .playlistName("Test Playlist")
+                .isPublic(true)
+                .build();
+
+        // Mock User, Playlist, MyPlaylist 객체 생성
+        User user = createMockUser(1L, "testUser", "Test User", "testUser@example.com", "testUserProfileImage",
+                UserRole.USER, "testUserSocialId");
+        Playlist playlist = createMockPlaylist(1L, "Test Playlist", true, false, user);
+        MyPlaylist myPlaylist = createMockMyPlaylist(1L, playlist, user);
+
+        given(userRepository.findById(1L)).willReturn(Optional.of(user));
+        given(playlistRepository.save(any(Playlist.class))).willReturn(playlist);
+        given(myPlaylistRepository.save(any(MyPlaylist.class))).willReturn(myPlaylist);
+
+        /* When */
+        CreatePlaylistResponseDto createPlaylistResponseDto = playlistService.createPlaylist(createPlaylistRequestDto);
+
+        /* Then */
+        assertThat(createPlaylistResponseDto.getPlaylistId()).isEqualTo(playlist.getId());
+        assertThat(createPlaylistResponseDto.getPlaylistName()).isEqualTo(playlist.getPlaylistName());
+        assertThat(createPlaylistResponseDto.getIsPublic()).isEqualTo(playlist.getIsPublic());
+        assertThat(createPlaylistResponseDto.getIsCurated()).isEqualTo(playlist.getIsCurated());
+    }
+
+    private User createMockUser(Long userId, String userName, String displayName, String userEmail, String profileImage,
+            UserRole role, String socialId) {
+        try {
+            Constructor<User> constructor = User.class.getDeclaredConstructor();
+            constructor.setAccessible(true);
+            User user = constructor.newInstance();
+
+            setField(user, "userId", userId);
+            setField(user, "userName", userName);
+            setField(user, "displayName", displayName);
+            setField(user, "userEmail", userEmail);
+            setField(user, "profileImage", profileImage);
+            setField(user, "role", role);
+            setField(user, "socialId", socialId);
+
+            return user;
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to create mock User", e);
+        }
+    }
+
+    private Playlist createMockPlaylist(Long id, String playlistName, boolean isPublic, boolean isCurated,
+            User user) {
+        try {
+            Constructor<Playlist> constructor = Playlist.class.getDeclaredConstructor();
+            constructor.setAccessible(true);
+            Playlist playlist = constructor.newInstance();
+
+            setField(playlist, "id", id);
+            setField(playlist, "playlistName", playlistName);
+            setField(playlist, "isPublic", isPublic);
+            setField(playlist, "isCurated", isCurated);
+            setField(playlist, "user", user);
+
+            return playlist;
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to create mock Playlist", e);
+        }
+    }
+
+    private MyPlaylist createMockMyPlaylist(Long id, Playlist playlist, User user) {
+        try {
+            Constructor<MyPlaylist> constructor = MyPlaylist.class.getDeclaredConstructor();
+            constructor.setAccessible(true);
+            MyPlaylist myPlaylist = constructor.newInstance();
+
+            setField(myPlaylist, "id", id);
+            setField(myPlaylist, "playlist", playlist);
+            setField(myPlaylist, "user", user);
+
+            return myPlaylist;
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to create mock MyPlaylist", e);
+        }
+    }
+
+    private void setField(Object target, String fieldName, Object value)
+            throws NoSuchFieldException, IllegalAccessException {
+        Field field = target.getClass().getDeclaredField(fieldName);
+        field.setAccessible(true);
+        field.set(target, value);
+    }
+}


### PR DESCRIPTION
### PR Type
<!— Please check the one that applies to this PR using "[x]" —>

- [x] Feat (기능 추가)
- [ ] Fix (버그 수정)
- [ ] Remove (파일 삭제)
- [ ] Rename (파일 이름 변경)
- [ ] Comment (코드 내 주석 추가, 수정, 삭제)
- [x] Test (테스트 추가, 테스트 리팩토링)
- [ ] Refactor (코드 리팩토링)
- [ ] Style (코드 형식 변경, 세미콜론 추가)
- [ ] Design (사용자 UI, CSS 변경)
- [ ] Docs (문서 수정)
- [ ] Build (빌드 관련)
- [ ] Other - Please Describe:


---
### Summary
1. **`PlaylistController` 추가**: `새 플레이리스트 생성하기` API 컨트롤러 구현.
2. **`CreatePlaylistRequestDto`, `CreatePlaylistResponseDto` 추가**: 플레이리스트 생성 요청 및 응답 데이터 전송 객체 추가.
3. **`MyPlaylist`, `Playlist` 엔티티 업데이트**: 빌더 패턴을 사용하여 객체 생성 로직 추가.
4. **`MyPlaylistRepository`, `PlaylistRepository`, `PlaylistTrackRepository` 인터페이스 추가**: 플레이리스트 및 플레이리스트 트랙 관련 JPA 리포지토리 인터페이스 추가.
5. **`PlaylistService` 추가**: `새 플레이리스트 생성하기` 비즈니스 로직 구현.
6. **`PlaylistControllerTest`, `PlaylistControllerUnitTest`, `PlaylistServiceTest` 추가**: 플레이리스트 관련 API에 대한 통합, 단위, 서비스 테스트 코드 추가.

---
### Description
- EndPoint: `/api/v1/playlists`
- HTTP Method `POST`
- Request Body
  ```json
  {
    "playlist_name": "도서관에서 듣는 노래",
    "is_public": true
  }
  ```
- Response Format
  ```json
  {
      "playlist_id": 1,
      "playlist_name": "Test Playlist",
      "is_public": true,
      "is_curated": false
  }
  ```

---
### Issue Number
close #36 