### PR TITLE
BE/#23 서비스 계층 메소드에서 `@Transactional(readOnly=true)` 명시하기

### DIFF
--- a/src/main/java/com/example/dreamvalutbackend/domain/genre/service/GenreService.java
+++ b/src/main/java/com/example/dreamvalutbackend/domain/genre/service/GenreService.java
@@ -8,6 +8,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.example.dreamvalutbackend.domain.genre.controller.response.GenreResponseDto;
 import com.example.dreamvalutbackend.domain.genre.controller.response.GenreWithTracksOverviewResponseDto;
@@ -31,6 +32,7 @@ public class GenreService {
     private final TrackRepository trackRepository;
     private final TrackDetailRepository trackDetailRepository;
 
+    @Transactional(readOnly = true)
     public Page<GenreWithTracksOverviewResponseDto> getGenresWithTracksOverview(Pageable pageable) {
         // 장르들 가져오기
         Page<Genre> genres = genreRepository.findAll(pageable);
@@ -50,12 +52,14 @@ public class GenreService {
         });
     }
 
+    @Transactional(readOnly = true)
     public List<GenreResponseDto> listAllGenres() {
         return genreRepository.findAll().stream()
                 .map(genre -> GenreResponseDto.toDto(genre))
                 .collect(Collectors.toList());
     }
 
+    @Transactional(readOnly = true)
     public GenreWithTracksResponseDto getGenreWithTracks(Long genreId, Pageable pageable) {
         // genreId로 해당하는 장르 가져오기
         Genre genre = genreRepository.findById(genreId)

--- a/src/main/java/com/example/dreamvalutbackend/domain/playlist/service/PlaylistService.java
+++ b/src/main/java/com/example/dreamvalutbackend/domain/playlist/service/PlaylistService.java
@@ -59,6 +59,7 @@ public class PlaylistService {
         return PlaylistResponseDto.toDto(savedPlaylist);
     }
 
+    @Transactional(readOnly = true)
     public PlaylistWithTracksResponseDto getPlaylistWithTracks(Long playlistId, Pageable pageable) {
         Playlist playlist = playlistRepository.findById(playlistId)
                 .orElseThrow(() -> new EntityNotFoundException("Playlist not found with id: " + playlistId));

--- a/src/main/java/com/example/dreamvalutbackend/domain/tag/service/TagService.java
+++ b/src/main/java/com/example/dreamvalutbackend/domain/tag/service/TagService.java
@@ -28,10 +28,12 @@ public class TagService {
     private final TrackTagRepository trackTagRepository;
     private final TrackDetailRepository trackDetailRepository;
 
+    @Transactional(readOnly = true)
     public Page<TagResponseDto> listAllTags(Pageable pageable) {
         return tagRepository.findAll(pageable).map(TagResponseDto::toDto);
     }
 
+    @Transactional(readOnly = true)
     public TagWithTracksResponseDto getTagWithTracks(Long tagId, Pageable pageable) {
         // tagId로 해당하는 태그 가져오기
         Tag tag = tagRepository.findById(tagId)

--- a/src/main/java/com/example/dreamvalutbackend/domain/track/service/TrackService.java
+++ b/src/main/java/com/example/dreamvalutbackend/domain/track/service/TrackService.java
@@ -84,6 +84,7 @@ public class TrackService {
 		return TrackUploadResponseDto.toDto(savedTrack);
 	}
 
+    @Transactional(readOnly = true)
 	public TrackResponseDto getTrack(Long trackId) {
 		// Track과 TrackDetail 가져오기
 		Track track = trackRepository.findById(trackId)


### PR DESCRIPTION
### PR Type
<!— Please check the one that applies to this PR using "[x]" —>

- [ ] Feat (기능 추가)
- [ ] Fix (버그 수정)
- [ ] Remove (파일 삭제)
- [ ] Rename (파일 이름 변경)
- [ ] Comment (코드 내 주석 추가, 수정, 삭제)
- [ ] Test (테스트 추가, 테스트 리팩토링)
- [x] Refactor (코드 리팩토링)
- [ ] Style (코드 형식 변경, 세미콜론 추가)
- [ ] Design (사용자 UI, CSS 변경)
- [ ] Docs (문서 수정)
- [ ] Build (빌드 관련)
- [ ] Other - Please Describe:


---
### Summary
- 서비스 계층에서 Read 작업만 수행되는 로직에서 `@Transactional(readOnly=true)` 명시하기
  1. 해당 메소드를 접한 사람이 `@Transactional(readOnly=true)` 어노테이션만으로 메소드의 역할을 유추할 수 있음 -> 가독성 증진
  2. 해당 어노테이션을 붙임으로써 JPA에서 변경 감지 작업을 수행하지 않고, 추가로 Transaction ID를 부여하지 않음 -> 성능 향상

---
### Description


---
### Issue Number
close #42 