### PR TITLE
BE/#31 `DreamvalutBackendApplicationTests` - `contextLoads()`에서 S3ClientProperties.getCredentials() 메소드 null 리턴 문제로 테스트 통과하지 못하는 문제 해결하기

### DIFF
--- a/src/main/java/com/example/dreamvalutbackend/DreamvalutBackendApplication.java
+++ b/src/main/java/com/example/dreamvalutbackend/DreamvalutBackendApplication.java
@@ -7,6 +7,7 @@ import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 @SpringBootApplication
 @ConfigurationPropertiesScan("com.example.dreamvalutbackend.config.aws")
 public class DreamvalutBackendApplication {
+
 	public static void main(String[] args) {
 		SpringApplication.run(DreamvalutBackendApplication.class, args);
 	}

--- a/src/test/java/com/example/dreamvalutbackend/DreamvalutBackendApplicationTests.java
+++ b/src/test/java/com/example/dreamvalutbackend/DreamvalutBackendApplicationTests.java
@@ -2,8 +2,10 @@ package com.example.dreamvalutbackend;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
+@ActiveProfiles("test")
 class DreamvalutBackendApplicationTests {
 
 	@Test


### PR DESCRIPTION
### PR Type
<!— Please check the one that applies to this PR using "[x]" —>

- [ ] Feat (기능 추가)
- [x] Fix (버그 수정)
- [ ] Remove (파일 삭제)
- [ ] Rename (파일 이름 변경)
- [ ] Comment (코드 내 주석 추가, 수정, 삭제)
- [x] Test (테스트 추가, 테스트 리팩토링)
- [ ] Refactor (코드 리팩토링)
- [ ] Style (코드 형식 변경, 세미콜론 추가)
- [ ] Design (사용자 UI, CSS 변경)
- [ ] Docs (문서 수정)
- [ ] Build (빌드 관련)
- [ ] Other - Please Describe:


---
### Summary
- `DreamvalutBackendApplicationTests` - `contextLoads()`에서 S3ClientProperties.getCredentials() 메소드 Null 리턴 문제로 테스트 통과하지 못하는 문제 해결
  - `@ActiveProfiles("test")` 어노테이션 명시하기

---
### Description


---
### Issue Number
close #58 