### PR TITLE
BE/#53 track 최신곡 받아오기 오류 수정 

### DIFF
--- a/src/main/java/com/example/dreamvalutbackend/domain/track/controller/TrackController.java
+++ b/src/main/java/com/example/dreamvalutbackend/domain/track/controller/TrackController.java
@@ -5,6 +5,7 @@ import java.net.URI;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -80,7 +81,7 @@ public class TrackController {
 	@GetMapping("/users/played")
 	public ResponseEntity<Page<TrackResponseDto>> getRecentTracks(
 		@AuthenticationPrincipal UserDetailPrincipal userDetailPrincipal,
-		@PageableDefault(size = 12, sort = "createdAt") Pageable pageable) {
+		@PageableDefault(size = 12, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
 
 		Long userId = userDetailPrincipal.getUserId();
 		Page<TrackResponseDto> recentTracks = trackService.getUserResentTrack(userId, pageable);

--- a/src/main/java/com/example/dreamvalutbackend/domain/track/repository/StreamingHistoryRepository.java
+++ b/src/main/java/com/example/dreamvalutbackend/domain/track/repository/StreamingHistoryRepository.java
@@ -11,8 +11,5 @@ import com.example.dreamvalutbackend.domain.track.domain.Track;
 
 @Repository
 public interface StreamingHistoryRepository extends JpaRepository<StreamingHistory, Long>, StreamingHistoryRepositoryCustom {
-	@Query("SELECT sh.track FROM StreamingHistory sh WHERE sh.user.userId = :userId ORDER BY sh.createdAt DESC")
-	Page<Track> findTracksByUserId(Long userId, Pageable pageable);
-
 
 }

--- a/src/main/java/com/example/dreamvalutbackend/domain/track/repository/StreamingHistoryRepositoryCustom.java
+++ b/src/main/java/com/example/dreamvalutbackend/domain/track/repository/StreamingHistoryRepositoryCustom.java
@@ -7,4 +7,6 @@ import com.example.dreamvalutbackend.domain.track.domain.Track;
 
 public interface StreamingHistoryRepositoryCustom {
 	Page<Track> findPopularTracks(Pageable pageable);
+
+	Page<Track> findDistinctAndRecentTracksByUserId(Long userId, Pageable pageable);
 }

--- a/src/main/java/com/example/dreamvalutbackend/domain/track/service/TrackService.java
+++ b/src/main/java/com/example/dreamvalutbackend/domain/track/service/TrackService.java
@@ -135,7 +135,7 @@ public class TrackService {
 
 	@Transactional
 	public Page<TrackResponseDto> getUserResentTrack(Long userId, Pageable pageable) {
-		Page<Track> tracks = streamingHistoryRepository.findTracksByUserId(userId, pageable);
+		Page<Track> tracks = streamingHistoryRepository.findDistinctAndRecentTracksByUserId(userId, pageable);
 		return tracks.map(track -> {
 			TrackDetail trackDetail = trackDetailRepository.findById(track.getId())
 				.orElseThrow(() -> new IllegalArgumentException("Track detail not found"));


### PR DESCRIPTION
id 중복 허용 및 변경 감지

---
name: pull_request
about: 'track 최신곡 받아오기 오류 수정 '
title: ''
labels: ''
assignees: ''

---

### PR Type
<!— Please check the one that applies to this PR using "[x]" —>

- [x] Feat (기능 추가)
- [x] Fix (버그 수정)
- [ ] Remove (파일 삭제)
- [ ] Rename (파일 이름 변경)
- [ ] Comment (코드 내 주석 추가, 수정, 삭제)
- [ ] Test (테스트 추가, 테스트 리팩토링)
- [ ] Refactor (코드 리팩토링)
- [ ] Style (코드 형식 변경, 세미콜론 추가)
- [ ] Design (사용자 UI, CSS 변경)
- [ ] Docs (문서 수정)
- [ ] Build (빌드 관련)
- [ ] Other - Please Describe:


---
### Summary
<img width="377" alt="image" src="https://github.com/DreamVault-2024/dreamvalut-backend/assets/121513336/6503753c-dabc-4c29-b3ab-599574beb067">


---
### Description
중복된 id는 그대로 중복되는 부분 수정(쿼리 형식이 제대로 안갖춰져 있어서 수정이 필요)
create_at을 기준으로 data를 받아오기 때문에 initsql에서 지정을 하지 않으면 random으로 뜨는 문제는 순서대로 뜨게 설정
<img width="450" alt="image" src="https://github.com/DreamVault-2024/dreamvalut-backend/assets/121513336/eca7b25b-9a10-4bad-b7bd-c0e9104ab1ce">
100개 데이터 중 중복 30개 제거
---
### Issue Number
